### PR TITLE
Add load JSON on start

### DIFF
--- a/tiers.js
+++ b/tiers.js
@@ -157,6 +157,8 @@ window.addEventListener('load', () => {
 		(evt || window.event).returnValue = msg;
 		return msg;
 	});
+
+	void try_load_tierlist_json();
 });
 
 function create_img_with_src(src) {
@@ -479,4 +481,26 @@ function set_layout(layout) {
 		main.classList.remove("vertical");
 	}
 	cur_layout = layout;
+}
+
+function is_url (str) {
+	try {
+		new URL(str);
+		return true;
+	} catch (e) {
+		return false;
+	}
+}
+
+// Fetches a tierlist JSON file from the 'url' query parameter and loads it
+async function try_load_tierlist_json () {
+	const load_from_url = new URLSearchParams(window.location.search).get('url');
+	if (load_from_url !== null && is_url(load_from_url)) {
+		try {
+			let result = await fetch(load_from_url);
+			result = await result.json();
+			hard_reset_list();
+			load_tierlist(result);
+		} catch (e) { console.error(e); }
+	}
 }


### PR DESCRIPTION
Closes #9 

I tried to keep the variable naming style. If you don't like how i added the feature, then definitely make your changes before merging.

Maybe @silverweed could also documentation on how to use the `url` query parameter. I could do it too, but you will probably do a better job (it's your repo).

There's also no indication that a JSON file is being loaded, which could be added as well, but I'll leave that up to you or anyone who would like to implement that.