### PR TITLE
Fixed Placement Marker Alignment with Row Titles

### DIFF
--- a/tiers.js
+++ b/tiers.js
@@ -298,9 +298,22 @@ function set_item_placement_marker_location(elem, is_hovering_row) {
 	// There is an 8px left margin offset before the tier begins (the blank gap)
 	// This subtraction accounts for that
 	h_offset -= 8;
+
 	if (is_hovering_row && !hovering_empty_bottom_container){
 		// Moves the vertical line to the right
-		h_offset += 100;
+		let position_info;
+		let row_header = elem.getElementsByClassName("header");
+		row_header = row_header[0];
+		if (row_header !== undefined){
+			// Hovering the row-droppable div
+			position_info = row_header.getBoundingClientRect();
+		}
+		else {
+			// Hovering the row header or header label
+			position_info = elem.getBoundingClientRect();
+		}
+
+		h_offset = position_info.right - 8;
 		placement_marker_div.style.marginLeft = h_offset + "px";
 	} else {
 		placement_marker_div.style.marginLeft = h_offset + "px";

--- a/tiers.js
+++ b/tiers.js
@@ -304,11 +304,10 @@ function set_item_placement_marker_location(elem, is_hovering_row) {
 		let position_info;
 		let row_header = elem.getElementsByClassName("header");
 		row_header = row_header[0];
-		if (row_header !== undefined){
+		if (row_header !== undefined) {
 			// Hovering the row-droppable div
 			position_info = row_header.getBoundingClientRect();
-		}
-		else {
+		} else {
 			// Hovering the row header or header label
 			position_info = elem.getBoundingClientRect();
 		}


### PR DESCRIPTION
Fixed: The placement marker was aligned incorrectly when the row title had a width greater than 100 pixels. This occurred when dragging an image over the header, header label, or the row.

![Screenshot 2025-04-10 110436](https://github.com/user-attachments/assets/a4c86490-d50f-477f-b049-82fe5a6bb3cc)

![Screenshot 2025-04-10 110420](https://github.com/user-attachments/assets/92fa4caf-6020-463c-beec-15c501fd9e2e)
